### PR TITLE
Easily run tests in a virtualenv with tox and nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
 testing/*.pyc
 testing/dumpgenerator.py
-
+/.tox

--- a/README.md
+++ b/README.md
@@ -56,3 +56,25 @@ See more options:
 ### Download Wikimedia Commons images
 
 There is a script for this, but we have [uploaded the tarballs](https://archive.org/details/wikimediacommons) to Internet Archive, so it's more useful to reseed their torrents than to re-generate old ones with the script.
+
+## Developers
+
+You can run tests easily by using the [tox](https://pypi.python.org/pypi/tox) command.  It is probably present in your operating system distribution, you would need version 1.6.  At worth, you can download it from pypi with: `pip install tox`.
+
+Example usage:
+
+    $ tox
+    py27 runtests: commands[0] | nosetests --nocapture --nologcapture
+    Checking http://wiki.annotation.jp/api.php
+    Trying to parse かずさアノテーション - ソーシャル・ゲノム・アノテーション.jpg from API
+    Retrieving image filenames
+    .    Found 266 images
+    .
+    -------------------------------------------
+    Ran 1 test in 2.253s
+
+    OK
+    _________________ summary _________________
+      py27: commands succeeded
+      congratulations :)
+    $

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+# 1.6 for skipsdist
+minversion = 1.6
+# Dont use setup.py (there is none)
+skipsdist = True
+# List of environement to run by default
+envlist = py27
+
+[testenv]
+# Test command with output reported
+commands = nosetests --nocapture --nologcapture
+deps = nose


### PR DESCRIPTION
tox is a nice wrapper around virtualenv. It setup a new env that makes
sure you have a clean install without any module beside the standard
one. If you need more modules, simply add them to 'deps =' and tox will
install them from pypi.

nose makes testing easier, it find any files that looks like a test and
run them for you.

The envs are created in /.tox so ignore that directory entirely.
