### PR TITLE
Issue #66 : try your.org first

### DIFF
--- a/commonsdownloader.py
+++ b/commonsdownloader.py
@@ -135,6 +135,8 @@ def main():
                     except OSError:
                         pass
                 else:
+                    # Issue #66 : try your.org first
+                    os.system('wget -c "http://ftpmirror.your.org/pub/wikimedia/images/wikipedia/commons/%s/%s/%s" -O "%s/%s"' % (md5hash[0], md5hash[0:2], img_name_quoted, savepath, img_saved_as_))
                     os.system('wget -c "http://upload.wikimedia.org/wikipedia/commons/%s/%s/%s" -O "%s/%s"' % (md5hash[0], md5hash[0:2], img_name_quoted, savepath, img_saved_as_))
                 
                 #curl .xml description page with full history


### PR DESCRIPTION
It's rather pointless to try to get a sensible error management with
os calls; just rely on wget -c to download the missing/incomplete files,
even though this will cause some additional connections.
