### PR TITLE
Fix argument parsing to accept delay as a number

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -990,7 +990,7 @@ def getParameters(params=[]):
     parser.add_argument(
         '--cookies', metavar="cookies.txt", help="path to a cookies.txt file")
     parser.add_argument(
-        '--delay', metavar=5, default=0, help="adds a delay (in seconds)")
+        '--delay', metavar=5, default=0, type=float, help="adds a delay (in seconds)")
     parser.add_argument(
         '--retries', metavar=5, default=5, help="Maximum number of retries for ")
     parser.add_argument('--path', help='path to store wiki dump at')


### PR DESCRIPTION
Hi,
I found that when I specified a delay (such as --delay 5) when running dumpgenerator.py, I received the error:

```
Traceback (most recent call last):
  File "dumpgenerator.py", line 1562, in <module>
    main()
  File "dumpgenerator.py", line 1554, in main
    createNewDump(config=config, other=other)
  File "dumpgenerator.py", line 1258, in createNewDump
    titles += getPageTitles(config=config, session=other['session'])
  File "dumpgenerator.py", line 325, in getPageTitles
    titles = getPageTitlesAPI(config=config, session=session)
  File "dumpgenerator.py", line 201, in getPageTitlesAPI
    config=config, session=session)
  File "dumpgenerator.py", line 170, in getNamespacesAPI
    delay(config=config, session=session)
  File "dumpgenerator.py", line 61, in delay
    print 'Sleeping... %d seconds...' % (config['delay'])
TypeError: %d format: a number is required, not str
```

Specifying a type (float) when using argparse will allow the delay argument to be read as a number, not a string. Please let me know if this fix is acceptable, thanks!
