### PR TITLE
Get as much information from siteinfo as possible

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1430,8 +1430,25 @@ def saveSiteInfo(config={}, session=None):
             print 'siteinfo.json exists, do not overwrite'
         else:
             print 'Downloading site info as siteinfo.json'
+            
+            # MediaWiki 1.13+
             r = session.post(url=config['api'], data={
-                             'action': 'query', 'meta': 'siteinfo', 'format': 'json'})
+                             'action': 'query',
+                             'meta': 'siteinfo',
+                             'siprop': 'general|namespaces|statistics|dbrepllag|interwikimap|namespacealiases|specialpagealiases|usergroups|extensions|skins|magicwords|fileextensions|rightsinfo',
+                             'sinumberingroup': 1,
+                             'format': 'json'})
+            # MediaWiki 1.11-1.12
+            if not 'query' in json.loads(r.text):
+                r = session.post(url=config['api'], data={
+                                 'action': 'query',
+                                 'meta': 'siteinfo',
+                                 'siprop': 'general|namespaces|statistics|dbrepllag|interwikimap',
+                                 'format': 'json'})
+            # MediaWiki 1.8-1.10
+            if not 'query' in json.loads(r.text):
+                r = session.post(url=config['api'], data={
+                                 'action': 'query', 'meta': 'siteinfo', 'siprop': 'general|namespaces', 'format': 'json'})
             result = json.loads(r.text)
             delay(config=config, session=session)
             with open('%s/siteinfo.json' % (config['path']), 'w') as outfile:


### PR DESCRIPTION
Properly fixes #97.

Algorithm:
1. Try all siteinfo props. If this gives an error, continue. Otherwise, stop.
2. Try MediaWiki 1.11-1.12 siteinfo props. If this gives an error, continue. Otherwise, stop.
3. Try minimal siteinfo props. Stop.
Not using sishowalldb=1 to avoid possible error (by default), since this data is of little use anyway.
