### PR TITLE
Preserve default headers, fixing openwrt test

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1070,7 +1070,7 @@ def getParameters(params=[]):
 
     session = requests.Session()
     session.cookies = cj
-    session.headers = {'User-Agent': getUserAgent()}
+    session.headers.update({'User-Agent': getUserAgent()})
     if args.user and args.password:
         session.auth = (args.user, args.password)
     # session.mount(args.api.split('/api.php')[0], HTTPAdapter(max_retries=max_ret))
@@ -1496,7 +1496,7 @@ def getWikiEngine(url=''):
     """ Returns the wiki engine of a URL, if known """
 
     session = requests.Session()
-    session.headers = {'User-Agent': getUserAgent()}
+    session.headers.update({'User-Agent': getUserAgent()})
     r = session.post(url=url)
     result = r.text
 
@@ -1517,7 +1517,7 @@ def mwGetAPIAndIndex(url=''):
     api = ''
     index = ''
     session = requests.Session()
-    session.headers = {'User-Agent': getUserAgent()}
+    session.headers.update({'User-Agent': getUserAgent()})
     r = session.post(url=url)
     result = r.text
     

--- a/testing/test_dumpgenerator.py
+++ b/testing/test_dumpgenerator.py
@@ -170,7 +170,7 @@ class TestDumpgenerator(unittest.TestCase):
     def test_getWikiEngine(self):
         tests = [
             ['https://www.dokuwiki.org', 'DokuWiki'],
-            #['http://wiki.openwrt.org', 'DokuWiki'],
+            ['http://wiki.openwrt.org', 'DokuWiki'],
             ['http://skilledtests.com/wiki/', 'MediaWiki'],
             ['http://moinmo.in', 'MoinMoin'],
             ['https://wiki.debian.org', 'MoinMoin'],


### PR DESCRIPTION
This problem was encountered when running
```bash
python dumpgenerator.py --get-wiki-engine http://wiki.openwrt.org
```
The server required an "Accept" HTTP header, which was being removed when setting the user-agent. It works now. Of course, it should be determined whether this behaviour was intentional or not before merging.
This **needs** to be tested before being merged.  It passes all the unit tests, but it might not work in all cases.