### PR TITLE
Improve getWikiEngine()

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1567,7 +1567,7 @@ def getWikiEngine(url=''):
     elif re.search(ur'(?im)(<div id="footer-pbwiki">|ws-nav-search|PBinfo *= *{)', result):
         # formerly PBwiki
         wikiengine = 'PBworks'
-    if wikiengine == 'Unknown': print result
+    #if wikiengine == 'Unknown': print result
 
     return wikiengine
 

--- a/testing/test_dumpgenerator.py
+++ b/testing/test_dumpgenerator.py
@@ -231,7 +231,7 @@ class TestDumpgenerator(unittest.TestCase):
             print 'Testing', wiki
             guess_engine = getWikiEngine(wiki)
             print 'Got: %s, expected: %s' % (guess_engine, engine)
-            self.assertEqual(getWikiEngine(wiki), engine)
+            self.assertEqual(guess_engine, engine)
     
     def test_mwGetAPIAndIndex(self):
         tests = [


### PR DESCRIPTION
Adds a bunch of wiki engines. This is still missing some notable wiki clones, such as UseModWiki and ikiwiki. However, this should be a good start. All "supported" wiki engines have at least one test case. Many have two. Some have more. This fixes #150.
