### PR TITLE
Fallback to getPageTitlesScraper() if API allpages disabled

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -326,7 +326,13 @@ def getPageTitles(config={}, session=None):
 
     titles = []
     if 'api' in config and config['api']:
-        titles = getPageTitlesAPI(config=config, session=session)
+        r = session.post(config['api'], {'action': 'query', 'list': 'allpages', 'format': 'json'})
+        test = json.loads(r.text)
+        if ('warnings' in test and 'allpages' in test['warnings'] and '*' in test['warnings']['allpages']
+                and test['warnings']['allpages']['*'] == 'The "allpages" module has been disabled.'):
+            titles = getPageTitlesScraper(config=config, session=session)
+        else:
+            titles = getPageTitlesAPI(config=config, session=session)
     elif 'index' in config and config['index']:
         titles = getPageTitlesScraper(config=config, session=session)
 


### PR DESCRIPTION
To reproduce the previous error, try http://www.wiki-aventurica.de/api.php

```
index.php is OK
#########################################################################
# Welcome to DumpGenerator 0.3.0-alpha by WikiTeam (GPL v3)                   #
# More info at: https://github.com/WikiTeam/wikiteam                    #
#########################################################################

#########################################################################
# Copyright (C) 2011-2014 WikiTeam                                      #
# This program is free software: you can redistribute it and/or modify  #
# it under the terms of the GNU General Public License as published by  #
# the Free Software Foundation, either version 3 of the License, or     #
# (at your option) any later version.                                   #
#                                                                       #
# This program is distributed in the hope that it will be useful,       #
# but WITHOUT ANY WARRANTY; without even the implied warranty of        #
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
# GNU General Public License for more details.                          #
#                                                                       #
# You should have received a copy of the GNU General Public License     #
# along with this program.  If not, see <http://www.gnu.org/licenses/>. #
#########################################################################

Analysing http://www.wiki-aventurica.de/api.php
Trying generating a new dump into a new directory...
Loading page titles from namespaces = all
Excluding titles from namespaces = None
24 namespaces found
    Retrieving titles in the namespace 0
.Traceback (most recent call last):
  File "dumpgenerator.py", line 1607, in <module>
    main()
  File "dumpgenerator.py", line 1599, in main
    createNewDump(config=config, other=other)
  File "dumpgenerator.py", line 1286, in createNewDump
    titles += getPageTitles(config=config, session=other['session'])
  File "dumpgenerator.py", line 329, in getPageTitles
    titles = getPageTitlesAPI(config=config, session=session)
  File "dumpgenerator.py", line 226, in getPageTitlesAPI
    allpages = jsontitles['query']['allpages']
KeyError: 'query'
```
