### PR TITLE
tests: Add .travis.yml and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python: 2.7
+install:
+  - pip install tox 
+script:
+  - tox


### PR DESCRIPTION
- Added .travis.yml to enable Travis CI

Signed-off-by: mr.Shu mr@shu.io

--- >8 ---

A response to #140. Since `tox` is being used to run tests, the `.travis.yml` is quite small.
