### PR TITLE
Add tox env for flake8 linter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,10 @@ commands = nosetests --nocapture --nologcapture
 deps =
     nose
     -rrequirements.txt
+
+[testenv:flake8]
+commands = flake8 {posargs}
+deps = flake8
+
+[flake8]
+exclude = .tox,.venv,build,dist,doc


### PR DESCRIPTION
Most people know about pep8 which enforce coding style.  pyflakes
goes a step beyond by analyzing the code.

flake8 is basically a wrapper around both pep8 and pyflakes and comes
with some additional checks.  I find it very useful since you only need
to require one package to have a lot of code issues reported to you.

This patch provides a 'flake8' tox environement to easily install
and run the utility on the code base.  One simply has to:

     tox -eflake8

The repository in its current state does not pass checks We can later
easily ensure there is no regression by adjusting Travis configuration
to run this env.

The env has NOT been added to the default list of environement.

More informations about flake8: https://pypi.python.org/pypi/flake8