### PR TITLE
convert images directory content to unicode when resuming download

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1585,7 +1585,7 @@ def resumePreviousDump(config={}, other={}):
         # checking images directory
         listdir = []
         try:
-            listdir = os.listdir('%s/images' % (config['path']))
+            listdir = [n.decode('utf-8') for n in os.listdir('%s/images' % (config['path']))]
         except:
             pass  # probably directory does not exist
         listdir.sort()


### PR DESCRIPTION
List of image file name needs to be converted to Unicode, because images list fetched from wiki is in Unicode.

Otherwise a test a few lines below fails for non-ascii image names:

`if filename2 not in listdir:`

