### PR TITLE
Make filename truncation work with UTF-8

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -59,7 +59,7 @@ def getVersion():
 def truncateFilename(other={}, filename=''):
     """ Truncate filenames when downloading images with large filenames """
     return filename[:other['filenamelimit']] + \
-        md5(filename).hexdigest() + '.' + filename.split('.')[-1]
+        md5(filename.encode('utf-8')).hexdigest() + '.' + filename.split('.')[-1]
 
 
 def delay(config={}, session=None):


### PR DESCRIPTION
Unicode is not supported by hashlib.
http://bugs.python.org/issue2948