### PR TITLE
Catch KeyError to fix server check

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1397,7 +1397,7 @@ def checkAPI(api=None, session=None):
                 index = result['query']['general']['server'] + \
                     result['query']['general']['script']
                 return ( True, index, api )
-            except ValueError:
+            except KeyError:
                 print "MediaWiki API seems to work but returned no index URL"
                 return (True, None, api)
     except ValueError:


### PR DESCRIPTION
ValueError would not be thrown there. It should have been KeyError.