### PR TITLE
When we have a working index.php, do not require api.php

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1358,8 +1358,11 @@ def getParameters(params=[]):
         api = check[2]
         print 'API is OK: ' + api
     else:
-        print 'Error in API. Please, provide a correct path to API'
-        sys.exit(1)
+        if index and not args.wiki:
+            print 'API not available. Trying with index.php only.'
+        else:
+            print 'Error in API. Please, provide a correct path to API'
+            sys.exit(1)
 
     if index and checkIndex(
             index=index,


### PR DESCRIPTION
We work well without api.php. this was a needless suicide.
Especially as sometimes sysadmins like to disable the API for no
reason and then index.php is our only option to archive the wiki.