### PR TITLE
http://www.mirkosertic.de is no longer powered by DokuWiki

### DIFF
--- a/listsofwikis/dokuwiki/dokuinstall.txt
+++ b/listsofwikis/dokuwiki/dokuinstall.txt
@@ -4957,7 +4957,6 @@ http://www.minkhollow.ca/becker/doku.php
 http://www.minkhollow.ca/mhf/doku.php
 http://www.minkhollow.ca/MHF/doku.php
 http://www.minkhollow.ca/Thesis07/doku.php
-http://www.mirkosertic.de/doku.php
 http://www.mirmer.su/wiki/doku.php
 http://www.mixshare.com/wiki/doku.php
 http://www.mixxx.org/wiki/doku.php


### PR DESCRIPTION
Removed http://www.mirkosertic.de from the list.