### PR TITLE
Use GET rather than POST for allpages API query

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -271,7 +271,7 @@ def getPageTitlesAPI(config={}, session=None):
             retryCount = 0
             while retryCount < config["retries"]:
                 try:
-                    r = session.post(url=config['api'], data=params, timeout=30)
+                    r = session.get(url=config['api'], params=params, timeout=30)
                     break
                 except ConnectionError as err:
                     print "Connection error: %s" % (str(err),)


### PR DESCRIPTION
POST does not follow the redirect from HTTP to HTTPS, which makes the
request (and the entire dump) fail if an API URL is passed like
http://7daystodie-de.gamepedia.com/api.php

Fixes https://github.com/WikiTeam/wikiteam/issues/334