### PR TITLE
Fix filename image dump bug for Gamepedia API

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1373,7 +1373,7 @@ def getImageNamesAPI(config={}, session=None):
                 url = curateImageURL(config=config, url=url)
                 # encoding to ascii is needed to work around this horrible bug:
                 # http://bugs.python.org/issue8136
-                if 'api' in config and ('.wikia.' in config['api'] or '.fandom.com' in config['api']):
+                if 'api' in config and ('.wikia.' in config['api'] or '.fandom.com' in config['api'] or '.gamepedia.com' in config['api']):
                     #to avoid latest?cb=20120816112532 in filenames
                     filename = unicode(urllib.unquote((re.sub('_', ' ', url.split('/')[-3])).encode('ascii', 'ignore')), 'utf-8')
                 else:


### PR DESCRIPTION
Gamepedia's image files were moved to Wikia's image servers, so dumping images with the script - given a Gamepedia API - causes the same latest?cb= filename bug that Wikia/Fandom Wikis experienced (Issue #362).

Example: 
https://dragalialost.gamepedia.com/File:Notte.png
https://static.wikia.nocookie.net/dragalialost_gamepedia_en/images/e/e8/Notte.png/revision/latest?cb=20180919220831