### PR TITLE
DumpGenerator: Move "debug" outputs to stdout for "clean" stderr

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1337,7 +1337,7 @@ def getImageNamesAPI(config={}, session=None):
     aifrom = '!'
     images = []
     while aifrom:
-        sys.stderr.write('.')  # progress
+        print '.'  # progress
         params = {
             'action': 'query',
             'list': 'allimages',
@@ -1388,7 +1388,7 @@ def getImageNamesAPI(config={}, session=None):
         gapfrom = '!'
         images = []
         while gapfrom:
-            sys.stderr.write('.')  # progress
+            print '.'  # progress
             # Some old APIs doesn't have allimages query
             # In this case use allpages (in nm=6) as generator for imageinfo
             # Example:


### PR DESCRIPTION
I redirect StdOut to /dev/null in scheduled wikidumps, to only receive a message when there is an actual error. These two debug outputs are still written to StdErr, which leads to me getting emails with just a single "." in them. I've moved them to regular stdout, but alternatively they could also be removed or replaced with a proper log message?