### PR TITLE
Fix image resuming

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -2242,7 +2242,7 @@ def resumePreviousDump(config={}, other={}):
         # checking images directory
         listdir = []
         try:
-            listdir = [n.decode('utf-8') for n in os.listdir('%s/images' % (config['path']))]
+            listdir = os.listdir('%s/images' % (config['path']))
         except:
             pass  # probably directory does not exist
         listdir.sort()


### PR DESCRIPTION
Before, with 50k images in the `images` directory:

```
0 images were found in the directory from a previous session
```

After:

```
53569 images were found in the directory from a previous session
```

---

- Python 2.7.18
- Linux 5.12.8-arch1-1

```
backports.csv==1.0.7
certifi==2020.12.5
chardet==4.0.0
contextlib2==0.6.0.post1
docopt==0.6.2
idna==2.10
internetarchive==2.0.3
jsonpatch==1.32
jsonpointer==2.1
kitchen==1.2.6
mwclient==0.10.1
oauthlib==3.1.0
requests==2.25.1
requests-oauthlib==1.3.0
schema==0.7.4
six==1.16.0
tqdm==4.60.0
urllib3==1.26.4
```