### PR TITLE
Add dump date to item identifier

### DIFF
--- a/uploader.py
+++ b/uploader.py
@@ -73,7 +73,7 @@ def upload(wikis, config={}, uploadeddumps=[]):
         for dump in dumps:
             wikidate = dump.split('-')[1]
             item = get_item('wiki-' + wikiname)
-            if item.exists and config.append_date:
+            if item.exists and config.append_date and not config.admin:
                 item = get_item('wiki-' + wikiname + '-' + wikidate)
             if dump in uploadeddumps:
                 if config.prune_directories:

--- a/uploader.py
+++ b/uploader.py
@@ -72,7 +72,10 @@ def upload(wikis, config={}, uploadeddumps=[]):
         c = 0
         for dump in dumps:
             wikidate = dump.split('-')[1]
-            item = get_item('wiki-' + wikiname + '-' + wikidate)
+            if config.append_date:
+                item = get_item('wiki-' + wikiname + '-' + wikidate)
+            else:
+                item = get_item('wiki-' + wikiname)
             if dump in uploadeddumps:
                 if config.prune_directories:
                     rmline='rm -rf %s-%s-wikidump/' % (wikiname, wikidate)
@@ -284,6 +287,7 @@ Use --help to print this help.""")
     parser.add_argument('-c', '--collection', default='opensource')
     parser.add_argument('-wd', '--wikidump_dir', default='.')
     parser.add_argument('-u', '--update', action='store_true')
+    parser.add_argument('-d', '--append_date', action='store_true')
     parser.add_argument('listfile')
     config = parser.parse_args()
     if config.admin:

--- a/uploader.py
+++ b/uploader.py
@@ -72,7 +72,7 @@ def upload(wikis, config={}, uploadeddumps=[]):
         c = 0
         for dump in dumps:
             wikidate = dump.split('-')[1]
-            item = get_item('wiki-' + wikiname)
+            item = get_item('wiki-' + wikiname + '-' + wikidate)
             if dump in uploadeddumps:
                 if config.prune_directories:
                     rmline='rm -rf %s-%s-wikidump/' % (wikiname, wikidate)

--- a/uploader.py
+++ b/uploader.py
@@ -72,10 +72,9 @@ def upload(wikis, config={}, uploadeddumps=[]):
         c = 0
         for dump in dumps:
             wikidate = dump.split('-')[1]
-            if config.append_date:
+            item = get_item('wiki-' + wikiname)
+            if item.exists and config.append_date:
                 item = get_item('wiki-' + wikiname + '-' + wikidate)
-            else:
-                item = get_item('wiki-' + wikiname)
             if dump in uploadeddumps:
                 if config.prune_directories:
                     rmline='rm -rf %s-%s-wikidump/' % (wikiname, wikidate)


### PR DESCRIPTION
Currently, `uploader.py` will fail due to permissions if a wikidump has been uploaded previously by another user. This change simply appends the `wikidate` to the identifier to standardize subsequent uploads instead of manual appends of `'-2'` or similar suffixes.

Before:
manual identifier change from `wiki-valorantfandomcom` -> `wiki-valorantfandomcom-2`

After:
unique identifier by dump date `wiki-valorantfandomcom-20220321`