### PR TITLE
Pin oauthlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ argparse>=1.2.1
 internetarchive
 kitchen
 mwclient
+oauthlib<=3.1.0
 requests>=2.3.0


### PR DESCRIPTION
`oauthlib` > 3.1.0 will not install with Python2 due to the use of type annotations

Pinning `oauthlib<=3.1.0` results in a successful install and `dumpgenerator.py` can be used.