### PR TITLE
Work around unicode titles not working with resuming and fix truncation when resuming

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -730,7 +730,7 @@ def generateXMLDump(config={}, titles=[], start=None, session=None):
 
     if config['xmlrevisions']:
         if start:
-            print("WARNING: will try to start the download from title: {}".format(start))
+            print("WARNING: will try to start the download from title: %s" % start)
             xmlfile = open('%s/%s' % (config['path'], xmlfilename), 'a')
         else:
             print 'Retrieving the XML for every page from the beginning'
@@ -1160,7 +1160,7 @@ def reverse_readline(filename, buf_size=8192, truncate=False):
                         fh.truncate
                         raise StopIteration
                     else:
-                        yield segment
+                        yield segment.decode('utf-8')
             segment = lines[0]
             for index in range(len(lines) - 1, 0, -1):
                 if truncate and '</page>' in segment:
@@ -1169,8 +1169,8 @@ def reverse_readline(filename, buf_size=8192, truncate=False):
                     fh.truncate
                     raise StopIteration
                 else:
-                    yield lines[index]
-        yield segment
+                    yield lines[index].decode('utf-8')
+        yield segment.decode('utf-8')
 
 def saveImageNames(config={}, images=[], session=None):
     """ Save image list in a file, including filename, url and uploader """

--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1155,21 +1155,19 @@ def reverse_readline(filename, buf_size=8192, truncate=False):
                     lines[-1] += segment
                 else:
                     if truncate and '</page>' in segment:
-                        pages = buffer.split('</page>')
-                        fh.seek(-offset+buf_size-len(pages[-1]), os.SEEK_END)
-                        fh.truncate
+                        fh.seek(-offset+buffer.rindex('</page>')+len('</page>\n'), os.SEEK_END)
+                        fh.truncate()
                         raise StopIteration
                     else:
                         yield segment.decode('utf-8')
-            segment = lines[0]
             for index in range(len(lines) - 1, 0, -1):
+                segment = lines[index]
                 if truncate and '</page>' in segment:
-                    pages = buffer.split('</page>')
-                    fh.seek(-offset-len(pages[-1]), os.SEEK_END)
-                    fh.truncate
+                    fh.seek(-offset+buffer.rindex('</page>\n')+len('</page>\n'), os.SEEK_END)
+                    fh.truncate()
                     raise StopIteration
                 else:
-                    yield lines[index].decode('utf-8')
+                    yield segment.decode('utf-8')
         yield segment.decode('utf-8')
 
 def saveImageNames(config={}, images=[], session=None):


### PR DESCRIPTION
Before, you would get `UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal`. The `%s` versus `{}` change was needed because otherwise you would get `UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)`. There is probably a better way of solving that, but this one does work.