### PR TITLE
Use `session.get` instead of `requests.get` in `getXMLHeader`

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -430,22 +430,22 @@ def getXMLHeader(config={}, session=None):
         try:
             print 'Getting the XML header from the API'
             # Export and exportnowrap exist from MediaWiki 1.15, allpages from 1.18
-            r = requests.get(config['api'] + '?action=query&export=1&exportnowrap=1&list=allpages&aplimit=1', timeout=10)
+            r = session.get(config['api'] + '?action=query&export=1&exportnowrap=1&list=allpages&aplimit=1', timeout=10)
             xml = r.text
             # Otherwise try without exportnowrap, e.g. Wikia returns a blank page on 1.19
             if not re.match(r"\s*<mediawiki", xml):
-                r = requests.get(config['api'] + '?action=query&export=1&list=allpages&aplimit=1&format=json', timeout=10)
+                r = session.get(config['api'] + '?action=query&export=1&list=allpages&aplimit=1&format=json', timeout=10)
                 try:
                     xml = r.json()['query']['export']['*']
                 except KeyError:
                     pass
             if not re.match(r"\s*<mediawiki", xml):
                 # Do without a generator, use our usual trick of a random page title
-                r = requests.get(config['api'] + '?action=query&export=1&exportnowrap=1&titles=' + randomtitle, timeout=10)
+                r = session.get(config['api'] + '?action=query&export=1&exportnowrap=1&titles=' + randomtitle, timeout=10)
                 xml = r.text
             # Again try without exportnowrap
             if not re.match(r"\s*<mediawiki", xml):
-                r = requests.get(config['api'] + '?action=query&export=1&format=json&titles=' + randomtitle, timeout=10)
+                r = session.get(config['api'] + '?action=query&export=1&format=json&titles=' + randomtitle, timeout=10)
                 try:
                     xml = r.json()['query']['export']['*']
                 except KeyError:


### PR DESCRIPTION
`session.get` uses our configured User-Agent, while `requests.get` uses the default one. Needed for `python2 -u dumpgenerator.py --xml --xmlrevisions --images https://fidopedia.fido.de/`, as that site rejects the requests user agent.

(That site also requires other stuff; see [this branch](https://github.com/Pokechu22/wikiteam/tree/fidopedia) ([perma](https://github.com/Pokechu22/wikiteam/tree/d43dedb304cb34a75595b8d4c70196488e72357f)), though that's not fully complete.)