### PR TITLE
Fix infinite loop on page title scraper

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -287,9 +287,9 @@ def getPageTitlesScraper(config={}, session=None):
 
         r_title = r'title="(?P<title>[^>]+)">'
         r_suballpages = ''
-        r_suballpages1 = r'&amp;from=(?P<from>[^>]+)&amp;to=(?P<to>[^>]+)">'
-        r_suballpages2 = r'Special:Allpages/(?P<from>[^>]+)">'
-        r_suballpages3 = r'&amp;from=(?P<from>[^>]+)" title="[^>]+">'
+        r_suballpages1 = r'&amp;from=(?P<from>[^>"]+)&amp;to=(?P<to>[^>"]+)">'
+        r_suballpages2 = r'Special:Allpages/(?P<from>[^>"]+)">'
+        r_suballpages3 = r'&amp;from=(?P<from>[^>"]+)" title="[^>]+">'
         if re.search(r_suballpages1, raw):
             r_suballpages = r_suballpages1
         elif re.search(r_suballpages2, raw):
@@ -299,7 +299,7 @@ def getPageTitlesScraper(config={}, session=None):
         else:
             pass  # perhaps no subpages
 
-        # Should be enought subpages on Special:Allpages
+        # Should be enough subpages on Special:Allpages
         deep = 50
         c = 0
         oldfr = ''
@@ -321,8 +321,8 @@ def getPageTitlesScraper(config={}, session=None):
                     name = '%s-%s' % (fr, to)
                     url = '%s?title=Special:Allpages&namespace=%s&from=%s&to=%s' % (
                         config['index'], namespace, fr, to)  # do not put urllib.quote in fr or to
-                # fix, esta regexp no carga bien todas? o falla el r_title en
-                # este tipo de subpag? (wikiindex)
+                # fix, this regexp doesn't properly save everything? or does r_title fail on this
+                # type of subpage? (wikiindex)
                 elif r_suballpages == r_suballpages2:
                     # clean &amp;namespace=\d, sometimes happens
                     fr = fr.split('&amp;namespace=')[0]


### PR DESCRIPTION
This affected [OSDev Wiki](https://wiki.osdev.org/Special:AllPages) (which lacks an api.php), where after doing the 4 normal pages of Special:AllPages, it would attempt `What_do_I_need_to_know_about_SMM-Zig_Bare_Bones"  title="This is a special page, you cannot edit the page itself` and then `What_do_I_need_to_know_about_SMM-Zig_Bare_Bones%22++title%3D%22This+is+a+special+page%2C+you+cannot+edit+the+page+itself"  title="This is a special page, you cannot edit the page itself`, repeating in an infinite loop. These URLs came from the "Special page" tab (which has that title text). The fix is to stop at quotes, meaning the regex won't match.  Quotes in actual URLs will be URL-encoded as `%22` so the regex won't interfere with those (see [enwiki](https://en.wikipedia.org/w/index.php?title=Special:AllPages&from=%22All-in%22+wrestling) as an example).

I also translated a comment from Spanish to English and fixed a typo in another comment. I don't know anything about the issue the Spanish comment is referring to, though.