### PR TITLE
Skip empty revisions when using --xmlrevisions

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -840,7 +840,13 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                         continue
 
                     for page in arvrequest['query']['allrevisions']:
-                        yield makeXmlFromPage(page)
+                        try:
+                            yield makeXmlFromPage(page)
+                        except PageMissingError as e:
+                            logerror(
+                                config=config,
+                                text=u'Error: empty revision from API. Skipping %s' % e
+                            )
                     if 'continue' in arvrequest:
                         arvparams['arvcontinue'] = arvrequest['continue']['arvcontinue']
                     else:


### PR DESCRIPTION
Before, the download would die, and need to be resumed from the start.

I ran into it while working on [this](https://archive.org/details/wiki-familysearch.org_en_wiki), which ended up dying on [FamilySearch Wiki:WikiProject England Parish Tables Part 2](https://www.familysearch.org/en/wiki/index.php?title=FamilySearch_Wiki:WikiProject_England_Parish_Tables_Part_2&action=history), which happens to have a deleted revision (apparently [the only deleted revision on a non-deleted page](https://www.familysearch.org/en/wiki/Special:Log?type=delete&user=&page=&wpdate=&tagfilter=&subtype=revision)). I was able to successfully redownload with this patch. (Well, I actually made another change so that it wouldn't restart from the beginning, but instead the project namespace - if I had had to redo everything, it would have lost half a week's data, but instead I only lost about half a day's data.)