### PR TITLE
Pass requests session to mwclient

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -258,7 +258,7 @@ def getPageTitlesAPI(config={}, session=None):
         c = 0
         print '    Retrieving titles in the namespace %d' % (namespace)
         apiurl = urlparse(config['api'])
-        site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme)
+        site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session)
         for page in site.allpages(namespace=namespace):
             title = page.name
             titles.append(title)
@@ -798,7 +798,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
     apiurl = urlparse(config['api'])
     # FIXME: force the protocol we asked for! Or don't verify SSL if we asked HTTP?
     # https://github.com/WikiTeam/wikiteam/issues/358
-    site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme)
+    site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session)
 
     if not 'all' in config['namespaces']:
         namespaces = config['namespaces']
@@ -1959,7 +1959,7 @@ def checkRetryAPI(api=None, retries=5, apiclient=False, session=None):
     if check and apiclient:
         apiurl = urlparse(api)
         try:
-            site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme)
+            site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session)
         except KeyError:
             # Probably KeyError: 'query'
             if apiurl.scheme == "https":
@@ -1971,7 +1971,7 @@ def checkRetryAPI(api=None, retries=5, apiclient=False, session=None):
             print("WARNING: The provided API URL did not work with mwclient. Switched protocol to: {}".format(newscheme))
 
             try:
-                site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=newscheme)
+                site = mwclient.Site(apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=newscheme, pool=session)
             except KeyError:
                 check = False
 


### PR DESCRIPTION
This means it uses our configured user-agent, as well as any cookies.

This was needed to save https://wiiki.wii-homebrew.com/Hauptseite and https://breath-of-the-wild.wii-homebrew.com/Hauptseite which are behind cloudflare. I completed the cloudflare challenge in my browser, and then saved the following into a file named `cookies.txt` (where `1698010873` is the expirey time as a unix timestamp - probably it could have been anything, and `longalphanumericstring` was the value seen in firefox's devtools, and the values are separated by tabs, and there was no trailing newline):

```
# Netscape HTTP Cookie File
.wii-homebrew.com	TRUE	/	TRUE	1698010873	cf_clearance	longalphanumericstring
```

Then running with `--cookies cookies.txt` worked properly.  Note that I also changed the user-agent to match what firefox currently uses (and what was used when I completed the challenge); I'm not sure if this was actually needed:

```diff
diff --git a/dumpgenerator.py b/dumpgenerator.py
index d99cb68..ef53999 100755
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -509,7 +509,8 @@ def getUserAgent():
         # firefox
         #'Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0',
         #'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0',
-        'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0'
+        #'Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0'
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:105.0) Gecko/20100101 Firefox/105.0'
     ]
     return useragents[0]
 
```