### PR TITLE
Fix crash when the image description is missing for an image containing non-ascii characters

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1515,8 +1515,8 @@ def generateImageDump(config={}, other={}, images=[], start='', session=None):
         imagefile.write(r.content)
         imagefile.close()
         # saving description if any
+        title = u'Image:%s' % (filename)
         try:
-            title = u'Image:%s' % (filename)
             if config['xmlrevisions'] and config['api'] and config['api'].endswith("api.php"):
                 r = session.get(config['api'] + u"?action=query&export&exportnowrap&titles=%s" % title)
                 xmlfiledesc = r.text
@@ -1529,7 +1529,7 @@ def generateImageDump(config={}, other={}, images=[], start='', session=None):
             xmlfiledesc = ''
             logerror(
                 config=config,
-                text=u'The page "%s" was missing in the wiki (probably deleted)' % (title.decode('utf-8'))
+                text=u'The page "%s" was missing in the wiki (probably deleted)' % title
             )
 
         f = open('%s/%s.desc' % (imagepath, filename2), 'w')


### PR DESCRIPTION
`title` is already unicode, so we shouldn't need to decode it (and don't in `generateXMLDump`):

https://github.com/WikiTeam/wikiteam/blob/25329be0088b4ece8cc2656f3654e85b5e73a9af/dumpgenerator.py#L777-L785

I ran into this at http://opensimulator.org/wiki/Main_Page, but it didn't occur when I re-ran it so I haven't fully tested this.  Here's the stacktrace from the time it failed though:

```
    Downloaded 450 images
Traceback (most recent call last):
  File "dumpgenerator.py", line 2573, in <module>
    main()
  File "dumpgenerator.py", line 2565, in main
    createNewDump(config=config, other=other)
  File "dumpgenerator.py", line 2144, in createNewDump
    session=other['session'])
  File "dumpgenerator.py", line 1532, in generateImageDump
    text=u'The page "%s" was missing in the wiki (probably deleted)' % (title.decode('utf-8'))
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf1' in position 11: ordinal not in range(128)
```

most likely referring to http://opensimulator.org/wiki/File:Peque%C3%B1agrid.jpg as U+00F1 is ñ.