### PR TITLE
Match single quotes too when scraping namespaces

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -170,7 +170,7 @@ def getNamespacesScraper(config={}, session=None):
 
         # [^>]*? to include selected="selected"
         m = re.compile(
-            r'<option [^>]*?value="(?P<namespaceid>\d+)"[^>]*?>(?P<namespacename>[^<]+)</option>').finditer(raw)
+            r'<option [^>]*?value=[\'"](?P<namespaceid>\d+)[\'"][^>]*?>(?P<namespacename>[^<]+)</option>').finditer(raw)
         if 'all' in namespaces:
             namespaces = []
             for i in m:


### PR DESCRIPTION
MediaWiki 1.36 HTML uses single quotes, as seen in https://wiki.othing.xyz

See also: https://github.com/elsiehupp/wikiteam3/pull/54