### PR TITLE
Quote `title` to get correct file description

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1519,7 +1519,7 @@ def generateImageDump(config={}, other={}, images=[], start='', session=None):
         title = u'Image:%s' % (filename)
         try:
             if config['xmlrevisions'] and config['api'] and config['api'].endswith("api.php"):
-                r = session.get(config['api'] + u"?action=query&export&exportnowrap&titles=%s" % title)
+                r = session.get(config['api'] + u"?action=query&export&exportnowrap&titles=%s" % urllib.prase.quote(title))
                 xmlfiledesc = r.text
             else:
                 xmlfiledesc = getXMLFileDesc(

--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1519,7 +1519,7 @@ def generateImageDump(config={}, other={}, images=[], start='', session=None):
         title = u'Image:%s' % (filename)
         try:
             if config['xmlrevisions'] and config['api'] and config['api'].endswith("api.php"):
-                r = session.get(config['api'] + u"?action=query&export&exportnowrap&titles=%s" % urllib.prase.quote(title))
+                r = session.get(config['api'] + u"?action=query&export&exportnowrap&titles=%s" % urllib.parse.quote(title))
                 xmlfiledesc = r.text
             else:
                 xmlfiledesc = getXMLFileDesc(


### PR DESCRIPTION
Fix empty .desc files caused by special characters such as `=` or `&` in the title.

See also: https://github.com/mediawiki-client-tools/wikiteam3/issues/75