### PR TITLE
Speed up file scanning in `images/` dir

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -2250,7 +2250,7 @@ def resumePreviousDump(config={}, other={}):
             listdir = os.listdir('%s/images' % (config['path']))
         except:
             pass  # probably directory does not exist
-        listdir.sort()
+        listdir = set(listdir)
         complete = True
         lastfilename = ''
         lastfilename2 = ''


### PR DESCRIPTION
Use `set` instead of `list` to speed up the scanning of large numbers of files (>10000) in `images/`.


---
Benchmark: (one million files in `images/` dir)

```
Set: one million files/s
List: 40 files/s
```