### PR TITLE
Fix: `--append_date` uploads to multiple IA items

### DIFF
--- a/uploader.py
+++ b/uploader.py
@@ -70,12 +70,13 @@ def upload(wikis, config={}, uploadeddumps=[]):
                 # break
 
         c = 0
+        identifier = 'wiki-' + wikiname
+        item = get_item(identifier)
+        first_item_exists = item.exists
         for dump in dumps:
-            wikidate = dump.split('-')[1]
-            identifier = 'wiki-' + wikiname
-            item = get_item(identifier)
-            if item.exists and config.append_date and not config.admin:
-                identifier += '-' + wikidate
+            wikidate = dump.name.split('-')[1]
+            if first_item_exists and config.append_date and not config.admin:
+                identifier = 'wiki-' + wikiname  + '-' + wikidate
                 item = get_item(identifier)
             if dump in uploadeddumps:
                 if config.prune_directories:

--- a/uploader.py
+++ b/uploader.py
@@ -248,6 +248,14 @@ def upload(wikis, config={}, uploadeddumps=[]):
             #Upload files and update metadata
             try:
                 item.upload(dumpdir + '/' + dump, metadata=md, access_key=accesskey, secret_key=secretkey, verbose=True, queue_derive=False)
+
+                retry = 20
+                while not item.exists and retry > 0:
+                    retry -= 1
+                    print "Waitting for item \"%s\" to be created... (%s)" % (identifier, retry)
+                    time.sleep(10)
+                    item = get_item(identifier)
+
                 item.modify_metadata(md) # update
                 print 'You can find it in https://archive.org/details/%s' % (identifier)
                 uploadeddumps.append(dump)

--- a/uploader.py
+++ b/uploader.py
@@ -256,7 +256,7 @@ def upload(wikis, config={}, uploadeddumps=[]):
                     time.sleep(10)
                     item = get_item(identifier)
 
-                item.modify_metadata(md) # update
+                item.modify_metadata(md, access_key=accesskey, secret_key=secretkey) # update
                 print 'You can find it in https://archive.org/details/%s' % (identifier)
                 uploadeddumps.append(dump)
             except Exception as e:


### PR DESCRIPTION
* Fix: <https://github.com/mediawiki-client-tools/mediawiki-scraper/issues/139>
* Waiting for item to be created before modifying metadata.
    > to avoid `item.modify_metadata()` raising error (like `Unable to locate identifier`).