### PR TITLE
Fix exporting via prop=revisions

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -983,7 +983,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                     'action': 'query',
                     'titles': '|'.join(titlelist),
                     'prop': 'revisions',
-                    #'rvlimit': 50,
+                    'rvlimit': 50,
                     'rvprop': 'ids|timestamp|user|userid|size|sha1|contentmodel|comment|content',
                 }
                 try:
@@ -1028,8 +1028,8 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                     # Get next batch of revisions if there's more.
                     if 'continue' in prequest.keys():
                         print("Getting more revisions for the page")
-                        for key, value in prequest['continue']:
-                            params[key] = value
+                        for key, value in prequest['continue'].iteritems():
+                            pparams[key] = value
                     elif 'query-continue' in prequest.keys():
                         rvstartid = prequest['query-continue']['revisions']['rvstartid']
                         pparams['rvstartid'] = rvstartid


### PR DESCRIPTION
This was sufficient to dump https://urbanculture.lol/ (which disables Special:Export and the allrevisions API, but supports prop=revisions). The commented out rvlimit line prevented getting more than 1 revision (`continue` wasn't present at all), while `prequest['continue']` failed because iterating over an `OrderedDict` (or a regular `dict`) iterates over the keys, and the variable that needs to be used is `pparams`, not `params` (which does not exist).

There's still a lot of jank with this path that will likely be found via other wikis. It's also jank that there's no way to directly specify this path, and instead it's only accessed via trying to use allrevisions (via `--xmlrevisions`) and that failing.