### PR TITLE
No longer strip <sha1> tags

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -624,12 +624,6 @@ def getXMLPage(config={}, title='', verbose=True, session=None):
         raise ExportAbortedError(config['index'])
     if not "</page>" in xml:
         raise PageMissingError(params['title'], xml)
-    else:
-        # strip these sha1s sums which keep showing up in the export and
-        # which are invalid for the XML schema (they only apply to
-        # revisions)
-        xml = re.sub(r'\n\s*<sha1>\w+</sha1>\s*\n', r'\n', xml)
-        xml = re.sub(r'\n\s*<sha1/>\s*\n', r'\n', xml)
 
     yield xml.split("</page>")[0]
 


### PR DESCRIPTION
It's 2023, and wikia isn't wikia anymore.  
Missing sha1 makes it impossible to import wikidump revisions dedupely.