### PR TITLE
Update requirements for mwclient to avoid error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse>=1.2.1
 internetarchive
 kitchen
-mwclient
+mwclient==0.10
 requests>=2.3.0


### PR DESCRIPTION
`pip install mwclient` will result in installing the latest version of mwclient (0.11 for now). However per #485, this will cause an error due to incompatibility. To fix this, mwclient==0.10 should be installed instead of 0.11